### PR TITLE
Chapter/4-resolver-args-parameter

### DIFF
--- a/server/src/datasources/track-api.js
+++ b/server/src/datasources/track-api.js
@@ -1,16 +1,20 @@
-const { RESTDataSource } = require('@apollo/datasource-rest');
+const { RESTDataSource } = require('@apollo/datasource-rest')
 
 class TrackAPI extends RESTDataSource {
   // the Catstronauts catalog is hosted on this server
-  baseURL = 'https://odyssey-lift-off-rest-api.herokuapp.com/';
+  baseURL = 'https://odyssey-lift-off-rest-api.herokuapp.com/'
 
-  getTracksForHome() {
-    return this.get('tracks');
+  getTracksForHome () {
+    return this.get('tracks')
   }
 
-  getAuthor(authorId) {
-    return this.get(`author/${authorId}`);
+  getAuthor (authorId) {
+    return this.get(`author/${authorId}`)
+  }
+
+  getTrack (trackId) {
+    return this.get(`track/${trackId}`)
   }
 }
 
-module.exports = TrackAPI;
+module.exports = TrackAPI

--- a/server/src/resolvers.js
+++ b/server/src/resolvers.js
@@ -2,14 +2,18 @@ const resolvers = {
   Query: {
     // returns an array of Tracks that will be used to populate the homepage grid of our web client
     tracksForHome: (_, __, { dataSources }) => {
-      return dataSources.trackAPI.getTracksForHome();
+      return dataSources.trackAPI.getTracksForHome()
     },
+    // get a single track by ID, for the track page
+    track: (_, { id }, { dataSources }) => {
+      return dataSources.trackAPI.getTrack(id)
+    }
   },
   Track: {
     author: ({ authorId }, _, { dataSources }) => {
-      return dataSources.trackAPI.getAuthor(authorId);
-    },
-  },
-};
+      return dataSources.trackAPI.getAuthor(authorId)
+    }
+  }
+}
 
-module.exports = resolvers;
+module.exports = resolvers


### PR DESCRIPTION
Chapter Link: [Resolver args parameter](https://www.apollographql.com/tutorials/lift-off-part3/04-resolver-args-parameter)

## Changes
- Add `getTrack` to the `TrackAPI` datasource
- Add `track` query to the resolver