### PR TITLE
Chapter 5: Resolver chains

### DIFF
--- a/server/src/datasources/track-api.js
+++ b/server/src/datasources/track-api.js
@@ -15,6 +15,10 @@ class TrackAPI extends RESTDataSource {
   getTrack (trackId) {
     return this.get(`track/${trackId}`)
   }
+
+  getTrackModules (trackId) {
+    return this.get(`track/${trackId}/modules`)
+  }
 }
 
 module.exports = TrackAPI

--- a/server/src/resolvers.js
+++ b/server/src/resolvers.js
@@ -12,6 +12,9 @@ const resolvers = {
   Track: {
     author: ({ authorId }, _, { dataSources }) => {
       return dataSources.trackAPI.getAuthor(authorId)
+    },
+    modules: ({ id }, _, { dataSources }) => {
+      return dataSources.trackAPI.getTrackModules(id)
     }
   }
 }


### PR DESCRIPTION
Chapter Link: [Resolver chains](https://www.apollographql.com/tutorials/lift-off-part3/05-resolver-chains)

## Changes
- Add `getTrackModules` to the `trackAPI` to retrieve the list of modules for a Track
- Add `modules` resolver to the `Track` type